### PR TITLE
fix: implement missing APIs for `ContentType`

### DIFF
--- a/src/FluentCMS.Services/ContentTypeService.cs
+++ b/src/FluentCMS.Services/ContentTypeService.cs
@@ -9,6 +9,7 @@ public interface IContentTypeService : IAutoRegisterService
     Task<ContentType> Delete(Guid appId, Guid contentTypeId, CancellationToken cancellationToken = default);
     Task<ContentType> SetField(Guid appId, Guid contentTypeId, ContentTypeField field, CancellationToken cancellationToken = default);
     Task<ContentType> DeleteField(Guid appId, Guid contentTypeId, string fieldSlug, CancellationToken cancellationToken = default);
+    Task<ContentType> GetById(Guid id, CancellationToken cancellationToken);
 }
 
 public class ContentTypeService(IContentTypeRepository contentTypeRepository) : IContentTypeService
@@ -98,5 +99,11 @@ public class ContentTypeService(IContentTypeRepository contentTypeRepository) : 
         //apply changes
         return await contentTypeRepository.Update(contentType, cancellationToken) ??
             throw new AppException(ExceptionCodes.ContentTypeUnableToUpdate);
+    }
+
+    public async Task<ContentType> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        return await contentTypeRepository.GetById(id, cancellationToken) ??
+               throw new AppException(ExceptionCodes.ContentTypeNotFound);
     }
 }

--- a/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
+++ b/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
@@ -1,7 +1,6 @@
 ﻿namespace FluentCMS.Web.Api.Controllers;
 
-public class ContentTypeController(IMapper mapper, IContentTypeService contentTypeService, IAppService appService)
-    : BaseAppController
+public class ContentTypeController(IMapper mapper, IContentTypeService contentTypeService, IAppService appService) : BaseAppController
 {
     [HttpGet("{slug}")]
     public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetBySlug([FromRoute] string slug, [FromRoute] string appSlug, CancellationToken cancellationToken = default)

--- a/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
+++ b/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
@@ -1,9 +1,30 @@
 ﻿namespace FluentCMS.Web.Api.Controllers;
 
-public class ContentTypeController(IMapper mapper, IContentTypeService contentTypeService, IAppService appService) : BaseAppController
+public class ContentTypeController(IMapper mapper, IContentTypeService contentTypeService, IAppService appService)
+    : BaseAppController
 {
+    [HttpGet("{slug}")]
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetBySlug([FromRoute] string slug,
+        [FromRoute] string appSlug, CancellationToken cancellationToken = default)
+    {
+        var app = await appService.GetBySlug(appSlug, cancellationToken);
+        var contentTypes = await contentTypeService.GetBySlug(app.Id, slug, cancellationToken);
+        var contentTypeResponses = mapper.Map<List<ContentTypeDetailResponse>>(contentTypes);
+        return OkPaged(contentTypeResponses);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetById([FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var contentTypes = await contentTypeService.GetById(id, cancellationToken);
+        var contentTypeResponses = mapper.Map<List<ContentTypeDetailResponse>>(contentTypes);
+        return OkPaged(contentTypeResponses);
+    }
+
     [HttpGet]
-    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetAll([FromRoute] string appSlug, CancellationToken cancellationToken = default)
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetAll([FromRoute] string appSlug,
+        CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var contentTypes = await contentTypeService.GetAll(app.Id, cancellationToken);
@@ -12,7 +33,8 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPost]
-    public async Task<IApiResult<ContentTypeDetailResponse>> Create([FromRoute] string appSlug, [FromBody] ContentTypeCreateRequest request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> Create([FromRoute] string appSlug,
+        [FromBody] ContentTypeCreateRequest request, CancellationToken cancellationToken = default)
     {
         var contentType = mapper.Map<ContentType>(request);
         var app = await appService.GetBySlug(appSlug, cancellationToken);
@@ -23,7 +45,8 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPut]
-    public async Task<IApiResult<ContentTypeDetailResponse>> Update([FromRoute] string appSlug, [FromBody] ContentTypeUpdateRequest request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> Update([FromRoute] string appSlug,
+        [FromBody] ContentTypeUpdateRequest request, CancellationToken cancellationToken = default)
     {
         var contentType = mapper.Map<ContentType>(request);
         var app = await appService.GetBySlug(appSlug, cancellationToken);
@@ -34,7 +57,8 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpDelete("{id}")]
-    public async Task<IApiResult<bool>> Delete([FromRoute] string appSlug, [FromRoute] Guid id, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<bool>> Delete([FromRoute] string appSlug, [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         await contentTypeService.Delete(app.Id, id, cancellationToken);
@@ -42,7 +66,8 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPut("{id}")]
-    public async Task<IApiResult<ContentTypeDetailResponse>> SetField([FromRoute] string appSlug, [FromRoute] Guid id, ContentTypeField request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> SetField([FromRoute] string appSlug, [FromRoute] Guid id,
+        ContentTypeField request, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var updated = await contentTypeService.SetField(app.Id, id, request, cancellationToken);
@@ -51,7 +76,8 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpDelete("{id}/{name}")]
-    public async Task<IApiResult<ContentTypeDetailResponse>> DeleteField([FromRoute] string appSlug, [FromRoute] Guid id, [FromRoute] string name, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> DeleteField([FromRoute] string appSlug,
+        [FromRoute] Guid id, [FromRoute] string name, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var updated = await contentTypeService.DeleteField(app.Id, id, name, cancellationToken);

--- a/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
+++ b/src/FluentCMS.Web.Api/Controllers/ContentTypeController.cs
@@ -4,8 +4,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     : BaseAppController
 {
     [HttpGet("{slug}")]
-    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetBySlug([FromRoute] string slug,
-        [FromRoute] string appSlug, CancellationToken cancellationToken = default)
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetBySlug([FromRoute] string slug, [FromRoute] string appSlug, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var contentTypes = await contentTypeService.GetBySlug(app.Id, slug, cancellationToken);
@@ -14,8 +13,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpGet("{id}")]
-    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetById([FromRoute] Guid id,
-        CancellationToken cancellationToken = default)
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetById([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
         var contentTypes = await contentTypeService.GetById(id, cancellationToken);
         var contentTypeResponses = mapper.Map<List<ContentTypeDetailResponse>>(contentTypes);
@@ -23,8 +21,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpGet]
-    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetAll([FromRoute] string appSlug,
-        CancellationToken cancellationToken = default)
+    public async Task<IApiPagingResult<ContentTypeDetailResponse>> GetAll([FromRoute] string appSlug, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var contentTypes = await contentTypeService.GetAll(app.Id, cancellationToken);
@@ -33,8 +30,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPost]
-    public async Task<IApiResult<ContentTypeDetailResponse>> Create([FromRoute] string appSlug,
-        [FromBody] ContentTypeCreateRequest request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> Create([FromRoute] string appSlug, [FromBody] ContentTypeCreateRequest request, CancellationToken cancellationToken = default)
     {
         var contentType = mapper.Map<ContentType>(request);
         var app = await appService.GetBySlug(appSlug, cancellationToken);
@@ -45,8 +41,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPut]
-    public async Task<IApiResult<ContentTypeDetailResponse>> Update([FromRoute] string appSlug,
-        [FromBody] ContentTypeUpdateRequest request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> Update([FromRoute] string appSlug, [FromBody] ContentTypeUpdateRequest request, CancellationToken cancellationToken = default)
     {
         var contentType = mapper.Map<ContentType>(request);
         var app = await appService.GetBySlug(appSlug, cancellationToken);
@@ -57,8 +52,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpDelete("{id}")]
-    public async Task<IApiResult<bool>> Delete([FromRoute] string appSlug, [FromRoute] Guid id,
-        CancellationToken cancellationToken = default)
+    public async Task<IApiResult<bool>> Delete([FromRoute] string appSlug, [FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         await contentTypeService.Delete(app.Id, id, cancellationToken);
@@ -66,8 +60,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpPut("{id}")]
-    public async Task<IApiResult<ContentTypeDetailResponse>> SetField([FromRoute] string appSlug, [FromRoute] Guid id,
-        ContentTypeField request, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> SetField([FromRoute] string appSlug, [FromRoute] Guid id, ContentTypeField request, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var updated = await contentTypeService.SetField(app.Id, id, request, cancellationToken);
@@ -76,8 +69,7 @@ public class ContentTypeController(IMapper mapper, IContentTypeService contentTy
     }
 
     [HttpDelete("{id}/{name}")]
-    public async Task<IApiResult<ContentTypeDetailResponse>> DeleteField([FromRoute] string appSlug,
-        [FromRoute] Guid id, [FromRoute] string name, CancellationToken cancellationToken = default)
+    public async Task<IApiResult<ContentTypeDetailResponse>> DeleteField([FromRoute] string appSlug, [FromRoute] Guid id, [FromRoute] string name, CancellationToken cancellationToken = default)
     {
         var app = await appService.GetBySlug(appSlug, cancellationToken);
         var updated = await contentTypeService.DeleteField(app.Id, id, name, cancellationToken);


### PR DESCRIPTION
closes #737 