### PR TITLE
912 failing update user api test

### DIFF
--- a/src/Tests/FluentCMS.E2eTests/Features/AppClient.feature
+++ b/src/Tests/FluentCMS.E2eTests/Features/AppClient.feature
@@ -1,4 +1,5 @@
 @RequiresFreshSetup
+@RequiresAuthenticatedAdmin
 Feature: App Client
 
 Background:

--- a/src/Tests/FluentCMS.E2eTests/Features/ContentTypeClient.feature
+++ b/src/Tests/FluentCMS.E2eTests/Features/ContentTypeClient.feature
@@ -1,5 +1,6 @@
 @RequiresFreshSetup
 @RequiresTestApp
+@RequiresAuthenticatedAdmin
 Feature: Content Type Client
 
 Background:

--- a/src/Tests/FluentCMS.E2eTests/Features/RoleClient.feature
+++ b/src/Tests/FluentCMS.E2eTests/Features/RoleClient.feature
@@ -1,5 +1,6 @@
 @RequiresFreshSetup
 @RequiresTestApp
+@RequiresAuthenticatedAdmin
 Feature: Role Client
 Background:
 	Given I have a "RoleClient"

--- a/src/Tests/FluentCMS.E2eTests/Features/UserClient.feature
+++ b/src/Tests/FluentCMS.E2eTests/Features/UserClient.feature
@@ -1,4 +1,5 @@
 @RequiresFreshSetup
+@RequiresAuthenticatedAdmin
 Feature: Basic User Client functionality
 
 Background:

--- a/src/Tests/FluentCMS.E2eTests/Features/UserClient.feature
+++ b/src/Tests/FluentCMS.E2eTests/Features/UserClient.feature
@@ -44,5 +44,6 @@ Scenario: Update user
 		| password | DummyPassw0rd!      |
 	When I create a user
 	Then user is created
+	Then Wait 1 second
 	When I update a user
 	Then user is updated

--- a/src/Tests/FluentCMS.E2eTests/StepDefinitions/Given/GivenIHaveAService.cs
+++ b/src/Tests/FluentCMS.E2eTests/StepDefinitions/Given/GivenIHaveAService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Net.Http.Headers;
+using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
 namespace FluentCMS.E2eTests.StepDefinitions;
@@ -10,6 +11,22 @@ public partial class StepDefinitions
         // find service type byName
         var definedTypes = Assembly.GetAssembly(typeof(ClientServiceExtensions))!.DefinedTypes;
         var serviceType = definedTypes.Single(x => x.Name == serviceName);
-        context[serviceType.FullName] = (context.GetServiceProvider().GetRequiredService(serviceType));
+        var service = (context.GetServiceProvider().GetRequiredService(serviceType));
+
+        // authorize if service is IApiClient and Token is available
+        if (serviceType.IsAssignableTo(typeof(IApiClient)))
+        {
+            if (context.ContainsKey(typeof(UserLoginResponseIApiResult).FullName))
+            {
+                var loginResponse = context.Get<UserLoginResponseIApiResult>();
+                var token = loginResponse.Data.Token;
+
+                var fieldInfo = serviceType.GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+                var value = fieldInfo?.GetValue(service);
+                HttpClient httpClient = ((HttpClient?)value) ?? throw new Exception("Could not find _httpClient");
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
+            }
+        }
+        context[serviceType.FullName] = service;
     }
 }

--- a/src/Tests/FluentCMS.E2eTests/StepDefinitions/Tags/RequiresAuthenticatedAdmin.cs
+++ b/src/Tests/FluentCMS.E2eTests/StepDefinitions/Tags/RequiresAuthenticatedAdmin.cs
@@ -1,0 +1,18 @@
+﻿namespace FluentCMS.E2eTests.StepDefinitions;
+public partial class StepDefinitions
+{
+    [Before("RequiresAuthenticatedAdmin", Order = 25)]
+    public async Task RequiresAuthenticatedAdmin()
+    {
+
+        var table = new Table("field", "value");
+        table.AddRow("username", "superadmin");
+        table.AddRow("password", "Passw0rd!");
+
+        GivenIHaveAService("AccountClient");
+        GivenIHaveCredentials(table);
+        await WhenIAuthenticateAsync();
+        ThenResponseErrorsShouldBeEmpty();
+        ThenIShouldHaveAToken();
+    }
+}

--- a/src/Tests/FluentCMS.E2eTests/StepDefinitions/Then/ThenResponseErrorsShouldNotBeEmpty.cs
+++ b/src/Tests/FluentCMS.E2eTests/StepDefinitions/Then/ThenResponseErrorsShouldNotBeEmpty.cs
@@ -5,7 +5,7 @@ public partial class StepDefinitions
     public void ThenResponseErrorsShouldNotBeEmpty()
     {
 
-        var errors = context.Get<ICollection<AppError>>();
+        var errors = context.Get<List<AppError>>();
         errors.ShouldNotBeEmpty();
     }
 }

--- a/src/Tests/FluentCMS.E2eTests/StepDefinitions/When/WhenIAuthenticateAsync.cs
+++ b/src/Tests/FluentCMS.E2eTests/StepDefinitions/When/WhenIAuthenticateAsync.cs
@@ -20,7 +20,7 @@ public partial class StepDefinitions
         catch (ApiClientException e)
         {
             // todo: fetch error messages
-
+            context.Set(e.Data.Errors);
         }
     }
 }


### PR DESCRIPTION
depends on #876 

user update tests were failing (Not Always)!

looks like a caching issue with DB

adding a delay between creation and modification fixes the issue!

needs more investigation

 will re-open the issue if a better solution is found

