### PR TITLE
fix: fix page padding bottom in iPhone Using env() in css

### DIFF
--- a/src/FluentCMS.Web.UI.Components/Components/Page/Page.scss
+++ b/src/FluentCMS.Web.UI.Components/Components/Page/Page.scss
@@ -16,7 +16,7 @@ $page: $prefix + 'page';
     }
 
     &-body {
-        @apply mb-12;
+        margin-bottom: calc(2rem + env(safe-area-inset-bottom, 1rem));
     }
 
     &-header {


### PR DESCRIPTION
closes #898