### PR TITLE
#1189 develop CSS name overriding feature

### DIFF
--- a/src/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
+++ b/src/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
@@ -19,7 +19,7 @@ public abstract class BaseComponent : ComponentBase
     [Parameter]
     public string? CSSName { get; set; }
 
-    public string GetDefaultCSSName()
+    public virtual string GetDefaultCSSName()
     {
         var type = GetType();
         if (type.IsGenericType)

--- a/src/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
+++ b/src/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
@@ -11,24 +11,21 @@ public abstract class BaseComponent : ComponentBase
     public RenderFragment ChildContent { get; set; } = default!;
 
     [Parameter]
-    public string Class { get; set; } = string.Empty;
+    public string? Class { get; set; }
 
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> AdditionalAttributes { get; set; } = default!;
 
-    public string ComponentName { get; } = string.Empty;
+    [Parameter]
+    public string? CSSName { get; set; }
 
-    public BaseComponent()
+    public string GetDefaultCSSName()
     {
         var type = GetType();
         if (type.IsGenericType)
-        {
-            ComponentName = type.Name.Split("`").First().FromPascalCaseToKebabCase();
-        }
+            return type.Name.Split("`").First().FromPascalCaseToKebabCase();
         else
-        {
-            ComponentName = type.Name.FromPascalCaseToKebabCase();
-        }
+            return type.Name.FromPascalCaseToKebabCase();
     }
 
     public override Task SetParametersAsync(ParameterView parameters)

--- a/src/FluentCMS.Web.UI.Components/Base/BaseComponentHelpers.cs
+++ b/src/FluentCMS.Web.UI.Components/Base/BaseComponentHelpers.cs
@@ -4,7 +4,7 @@ public static class BaseComponentHelper
 {
 
     // css prefix for auto-generated classes
-    public const string PREFIX = "f";
+    public const string CSS_PREFIX = "f";
 
     public const string SEPARATOR = "-";
 
@@ -12,7 +12,7 @@ public static class BaseComponentHelper
     {
         ArgumentNullException.ThrowIfNull(baseComponent);
 
-        return string.Join(SEPARATOR, [PREFIX, Name.FromPascalCaseToKebabCase()]);
+        return string.Join(SEPARATOR, [CSS_PREFIX, Name.FromPascalCaseToKebabCase()]);
     }
 
     public static List<string> ClassNames(this BaseComponent baseComponent)
@@ -24,6 +24,8 @@ public static class BaseComponentHelper
             GetProperties().
             Where(p => p.CustomAttributes.Any(x => x.AttributeType == typeof(CSSPropertyAttribute)));
 
+        var cssName = baseComponent.CSSName?.FromPascalCaseToKebabCase() ?? baseComponent.GetDefaultCSSName();
+
         foreach (var property in properties)
         {
             if (property.GetValue(baseComponent, null) is var value)
@@ -31,7 +33,7 @@ public static class BaseComponentHelper
                 if (value != null)
                 {
                     var propertyValue = value.ToString()?.FromPascalCaseToKebabCase() ?? string.Empty;
-                    classes.Add(string.Join(SEPARATOR, [PREFIX, baseComponent.ComponentName, property.Name.FromPascalCaseToKebabCase(), propertyValue]));
+                    classes.Add(string.Join(SEPARATOR, [CSS_PREFIX, cssName, property.Name.FromPascalCaseToKebabCase(), propertyValue]));
                 }
             }
         }
@@ -41,11 +43,17 @@ public static class BaseComponentHelper
 
     public static string GetClasses(this BaseComponent baseComponent)
     {
+        var cssName = baseComponent.CSSName?.FromPascalCaseToKebabCase() ?? baseComponent.GetDefaultCSSName();
+
         // component's class name from its name (f-button, f-badge, etc.)
-        var componentCss = string.Join(SEPARATOR, [PREFIX, baseComponent.ComponentName]);
+        var componentCss = string.Join(SEPARATOR, [CSS_PREFIX, cssName]);
 
         // add css properties
-        List<string> classes = [componentCss, .. ClassNames(baseComponent), baseComponent.Class];
+        List<string> classes = [componentCss, .. ClassNames(baseComponent)];
+
+        // if class is set by user, add the same class name
+        if (!string.IsNullOrEmpty(baseComponent.Class))
+            classes = [.. classes, baseComponent.Class];
 
         return string.Join(" ", classes);
     }


### PR DESCRIPTION
@abdolian @ParsaGachkar @TheHadiAhmadi @babakhani 

There are two type of usages:

1. You are using a component and you want to override the css name:

```
<Button CSSName="Test" Color="Color.Default">
    Default
</Button>
```

2. You are inheriting from another component

```
public override string GetDefaultCSSName()
{
    return "TestAmir";
}
```

As before, if you set the `Class` property, the same string will be added to the end of generated class names.