### PR TITLE
Implement ILayoutProcessor interface

### DIFF
--- a/src/Frontend/FluentCMS.Web.UI/Default.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI/Default.razor.cs
@@ -8,7 +8,7 @@ namespace FluentCMS.Web.UI;
 public partial class Default : IDisposable
 {
     [Inject]
-    public LayoutProcessor LayoutProcessor { get; set; } = default!;
+    private ILayoutProcessor LayoutProcessor { get; set; } = default!;
 
     [CascadingParameter]
     public ViewContext ViewContext { get; set; } = default!;

--- a/src/Frontend/FluentCMS.Web.UI/DynamicRendering/LayoutProcessor.cs
+++ b/src/Frontend/FluentCMS.Web.UI/DynamicRendering/LayoutProcessor.cs
@@ -4,7 +4,12 @@ using System.Text.RegularExpressions;
 
 namespace FluentCMS.Web.UI.DynamicRendering;
 
-public class LayoutProcessor(UserLoginResponse userLogin)
+public interface ILayoutProcessor
+{
+    List<Segment> ProcessSegments(string htmlContent);
+}
+
+public class LayoutProcessor(UserLoginResponse userLogin) : ILayoutProcessor
 {
     private string PreProcess(string? content)
     {

--- a/src/Frontend/FluentCMS.Web.UI/ServiceExtensions.cs
+++ b/src/Frontend/FluentCMS.Web.UI/ServiceExtensions.cs
@@ -15,7 +15,7 @@ public static class ServiceExtensions
     {
         services.AddSingleton<PluginLoader>();
 
-        services.AddScoped<LayoutProcessor>();
+        services.AddScoped<ILayoutProcessor, LayoutProcessor>();
 
         // Add services to the container.
         services.AddRazorComponents()


### PR DESCRIPTION
- Introduced ILayoutProcessor interface in FluentCMS.Web.UI.DynamicRendering, making LayoutProcessor adhere to this new abstraction for better flexibility and future extensibility.
- Updated dependency injection in Default.razor.cs to use ILayoutProcessor, aligning with the Dependency Inversion Principle. Changed the access modifier of the LayoutProcessor property from public to private to enhance encapsulation.
- Modified service registration in ServiceExtensions.cs to register ILayoutProcessor as the service type and LayoutProcessor as the implementation, promoting decoupling and ease of future modifications.