### PR TITLE
Refactor AuthManager for ApiClientFactory

### DIFF
--- a/src/Frontend/FluentCMS.Web.ApiClients/Services/AuthManager.cs
+++ b/src/Frontend/FluentCMS.Web.ApiClients/Services/AuthManager.cs
@@ -5,7 +5,7 @@ using System.Security.Claims;
 
 namespace FluentCMS.Web.ApiClients.Services;
 
-public class AuthManager(IHttpClientFactory httpClientFactory)
+public class AuthManager(ApiClientFactory apiClient)
 {
     public async Task Logout(HttpContext httpContext)
     {
@@ -18,9 +18,7 @@ public class AuthManager(IHttpClientFactory httpClientFactory)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        var httpClient = httpClientFactory.CreateClient("FluentCMS.Web.Api");
-        var accountClient = new AccountClient(httpClient);
-        var accountResponse = await accountClient.AuthenticateAsync(new UserLoginRequest
+        var accountResponse = await apiClient.Account.AuthenticateAsync(new UserLoginRequest
         {
             Username = username,
             Password = password,


### PR DESCRIPTION
Refactored `AuthManager` to utilize `ApiClientFactory` instead of `IHttpClientFactory`, streamlining the creation and usage of API clients within the class. The constructor now accepts an `ApiClientFactory` instance, enhancing the instantiation process of API clients. Additionally, the `Login` method has been simplified by directly using the `apiClient` to access an `Account` client for authentication, removing the need to manually create `HttpClient` and `AccountClient` instances. This change aims to simplify and improve the efficiency of the authentication process.