### PR TITLE
Refactor and clean up Razor component files

### DIFF
--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormAutocomplete/FormAutocompleteMultiple.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormAutocomplete/FormAutocompleteMultiple.razor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 namespace FluentCMS.Web.UI.Components;
 

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/FileManagement/FileListPlugin.razor.cs
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/FileManagement/FileListPlugin.razor.cs
@@ -35,7 +35,8 @@ public partial class FileListPlugin
         {
             if (folder.Id == folderId)
             {
-                BreadcrumbItems.Add( new FolderBreadcrumbItemType {
+                BreadcrumbItems.Add(new FolderBreadcrumbItemType
+                {
                     Title = folder.Name,
                 });
                 return folder;
@@ -46,9 +47,10 @@ public partial class FileListPlugin
                 var foundFolder = FindFolderById(folder.Folders, folderId);
                 if (foundFolder != null)
                 {
-                    BreadcrumbItems.Add( new FolderBreadcrumbItemType {
+                    BreadcrumbItems.Add(new FolderBreadcrumbItemType
+                    {
                         Title = folder.Name,
-                        Href = GetUrl("Files List", new { folderId = folder.Id }) 
+                        Href = GetUrl("Files List", new { folderId = folder.Id })
                     });
                     return foundFolder;
                 }
@@ -89,7 +91,8 @@ public partial class FileListPlugin
 
             if (FolderId is null || FolderId == Guid.Empty)
             {
-                BreadcrumbItems.Add( new FolderBreadcrumbItemType {
+                BreadcrumbItems.Add(new FolderBreadcrumbItemType
+                {
                     Icon = IconName.Folder,
                     Title = "Root"
                 });
@@ -99,10 +102,11 @@ public partial class FileListPlugin
             {
                 folderDetail = FindFolderById(RootFolder!.Folders, FolderId.Value);
 
-                BreadcrumbItems.Add( new FolderBreadcrumbItemType {
+                BreadcrumbItems.Add(new FolderBreadcrumbItemType
+                {
                     Icon = IconName.Folder,
                     Title = "Root",
-                    Href = GetUrl("Files List", new { folderId = Guid.Empty }) 
+                    Href = GetUrl("Files List", new { folderId = Guid.Empty })
                 });
                 BreadcrumbItems.Reverse();
             }
@@ -124,7 +128,7 @@ public partial class FileListPlugin
                     });
                 }
 
-                if(folderDetail != null)
+                if (folderDetail != null)
                 {
                     foreach (var item in folderDetail.Folders)
                     {


### PR DESCRIPTION
- Removed unused `System.Globalization` in `FormAutocompleteMultiple.razor.cs`.
- Adjusted and standardized brace formatting in `FileListPlugin.razor.cs`.
- Removed unnecessary spaces before braces in `FileListPlugin.razor.cs`.
- Corrected spacing around `if` statements in `FileListPlugin.razor.cs` for better readability.