### PR TITLE
Move ChildComponent parameter from BaseComponent to components that use them (fixes #1577)

### DIFF
--- a/src/Frontend/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Base/BaseComponent.cs
@@ -6,9 +6,6 @@ public abstract class BaseComponent : ComponentBase, IBaseComponent
     public bool Visible { get; set; } = true;
 
     [Parameter]
-    public RenderFragment ChildContent { get; set; } = default!;
-
-    [Parameter]
     public string? Class { get; set; }
 
     [Parameter(CaptureUnmatchedValues = true)]

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
@@ -34,8 +34,8 @@ public partial class Accordion : IAsyncDisposable
     [Parameter]
     public EventCallback<bool> OpenChanged { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
 	public ElementReference Element;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
@@ -34,7 +34,10 @@ public partial class Accordion : IAsyncDisposable
     [Parameter]
     public EventCallback<bool> OpenChanged { get; set; }
 
-    public ElementReference Element;
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Accordion/Accordion.razor.cs
@@ -37,7 +37,7 @@ public partial class Accordion : IAsyncDisposable
     [Parameter]
     public RenderFragment ChildContent { get; set; } = default!;
 
-	public ElementReference Element;
+    public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Alert/Alert.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Alert/Alert.razor.cs
@@ -9,6 +9,9 @@ public partial class Alert
     [CSSProperty]
     public AlertType Type { get; set; }
 
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
+
     private Task Close()
     {
         Visible = false;

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Avatar/Avatar.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Avatar/Avatar.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Avatar
 {
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Badge/Badge.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Badge/Badge.razor.cs
@@ -5,4 +5,7 @@ public partial class Badge
     [Parameter]
     [CSSProperty]
     public Color Color { get; set; } = Color.Default;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Badge/Badge.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Badge/Badge.razor.cs
@@ -6,6 +6,6 @@ public partial class Badge
     [CSSProperty]
     public Color Color { get; set; } = Color.Default;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/Breadcrumb.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/Breadcrumb.razor.cs
@@ -1,6 +1,6 @@
-namespace FluentCMS.Web.UI.Components;
+﻿namespace FluentCMS.Web.UI.Components;
 
-public partial class Card
+public partial class Breadcrumb
 {
 	[Parameter]
 	public RenderFragment ChildContent { get; set; } = default!;

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/Breadcrumb.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/Breadcrumb.razor.cs
@@ -2,6 +2,6 @@
 
 public partial class Breadcrumb
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/BreadcrumbItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Breadcrumb/BreadcrumbItem.razor.cs
@@ -7,4 +7,7 @@ public partial class BreadcrumbItem
 
     [Parameter]
     public IconName IconName { get; set; } = IconName.Default;
+
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Button/Button.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Button/Button.razor.cs
@@ -35,4 +35,7 @@ public partial class Button
 
     [Parameter]
     public ButtonType Type { get; set; } = ButtonType.Button;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Button/Button.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Button/Button.razor.cs
@@ -36,6 +36,6 @@ public partial class Button
     [Parameter]
     public ButtonType Type { get; set; } = ButtonType.Button;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/Card.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/Card.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Card
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardActions.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardActions.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardActions
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardActions.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardActions.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardActions
 {
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardBody.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardBody.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardBody
 {
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardBody.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardBody.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardBody
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardHeader.razor.cs
@@ -5,6 +5,6 @@ public partial class CardHeader
     [Parameter]
     public string? Title { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardHeader.razor.cs
@@ -4,4 +4,7 @@ public partial class CardHeader
 {
     [Parameter]
     public string? Title { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardTitle.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardTitle.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardTitle
 {
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardTitle.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Card/CardTitle.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class CardTitle
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Confirm/Confirm.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Confirm/Confirm.razor.cs
@@ -12,7 +12,10 @@ public partial class Confirm
     [Parameter]
     public EventCallback OnCancel { get; set; }
 
-    [JSInvokable]
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	[JSInvokable]
     public async Task CancelClicked()
     {
         Visible = false;

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Confirm/Confirm.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Confirm/Confirm.razor.cs
@@ -12,10 +12,10 @@ public partial class Confirm
     [Parameter]
     public EventCallback OnCancel { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	[JSInvokable]
+    [JSInvokable]
     public async Task CancelClicked()
     {
         Visible = false;

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/DataTable/DataTable.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/DataTable/DataTable.razor.cs
@@ -8,4 +8,7 @@ public partial class DataTable<TItem>
     [Parameter]
     [CSSProperty]
     public bool Hoverable { get; set; } = true;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/DataTable/DataTable.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/DataTable/DataTable.razor.cs
@@ -9,6 +9,6 @@ public partial class DataTable<TItem>
     [CSSProperty]
     public bool Hoverable { get; set; } = true;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Divider/Divider.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Divider/Divider.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Divider
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Divider/Divider.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Divider/Divider.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Divider
 {
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/Dropdown.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/Dropdown.razor.cs
@@ -30,10 +30,10 @@ public partial class Dropdown : IAsyncDisposable
     [Parameter]
     public EventCallback<bool> OpenChanged { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public ElementReference Element;
+    public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/Dropdown.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/Dropdown.razor.cs
@@ -30,7 +30,10 @@ public partial class Dropdown : IAsyncDisposable
     [Parameter]
     public EventCallback<bool> OpenChanged { get; set; }
 
-    public ElementReference Element;
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownItem.razor.cs
@@ -11,10 +11,10 @@ public partial class DropdownItem
     [Parameter]
     public EventCallback OnClick { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	private async Task OnClicked()
+    private async Task OnClicked()
     {
         Parent?.Close();
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownItem.razor.cs
@@ -11,7 +11,10 @@ public partial class DropdownItem
     [Parameter]
     public EventCallback OnClick { get; set; }
 
-    private async Task OnClicked()
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	private async Task OnClicked()
     {
         Parent?.Close();
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownMenu.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownMenu.razor.cs
@@ -2,5 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class DropdownMenu
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownMenu.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Dropdown/DropdownMenu.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class DropdownMenu
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormField/FormField.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormField/FormField.razor.cs
@@ -19,4 +19,7 @@ public partial class FormField
 
     [Parameter]
     public bool Required { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormField/FormField.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormField/FormField.razor.cs
@@ -20,6 +20,6 @@ public partial class FormField
     [Parameter]
     public bool Required { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormFileUpload/FormFileUpload.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormFileUpload/FormFileUpload.razor.cs
@@ -28,12 +28,12 @@ public partial class FormFileUpload : IAsyncDisposable
     [Parameter]
     public bool Required { get; set; }
 
-	#endregion
+    #endregion
 
-	[Inject]
-	public IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    public IJSRuntime JS { get; set; } = default!;
 
-	[Parameter]
+    [Parameter]
     public int Cols { get; set; } = 12;
 
     [Parameter]
@@ -45,10 +45,10 @@ public partial class FormFileUpload : IAsyncDisposable
     [Parameter]
     public EventCallback<InputFileChangeEventArgs> OnChange { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public ElementReference Element;
+    public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormFileUpload/FormFileUpload.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormFileUpload/FormFileUpload.razor.cs
@@ -28,13 +28,13 @@ public partial class FormFileUpload : IAsyncDisposable
     [Parameter]
     public bool Required { get; set; }
 
-    #endregion
+	#endregion
 
-    [Parameter]
+	[Inject]
+	public IJSRuntime JS { get; set; } = default!;
+
+	[Parameter]
     public int Cols { get; set; } = 12;
-
-    [Inject]
-    public IJSRuntime? JS { get; set; }
 
     [Parameter]
     public string? Accept { get; set; }
@@ -45,7 +45,10 @@ public partial class FormFileUpload : IAsyncDisposable
     [Parameter]
     public EventCallback<InputFileChangeEventArgs> OnChange { get; set; }
 
-    public ElementReference Element;
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public ElementReference Element;
 
     public IJSObjectReference Module = default!;
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormLabel/FormLabel.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormLabel/FormLabel.razor.cs
@@ -7,4 +7,7 @@ public partial class FormLabel
 
     [Parameter]
     public bool Required { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormLabel/FormLabel.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Form/FormLabel/FormLabel.razor.cs
@@ -8,6 +8,6 @@ public partial class FormLabel
     [Parameter]
     public bool Required { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/Grid.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/Grid.razor.cs
@@ -54,6 +54,6 @@ public partial class Grid
     [CSSProperty]
     public bool NoWrap { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/Grid.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/Grid.razor.cs
@@ -53,4 +53,7 @@ public partial class Grid
     [Parameter]
     [CSSProperty]
     public bool NoWrap { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
@@ -34,6 +34,6 @@ public partial class GridItem
 
 	#endregion
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
@@ -32,5 +32,8 @@ public partial class GridItem
     [CSSProperty]
     public bool? HideLarge { get; set; }
 
-    #endregion
+	#endregion
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Grid/GridItem.razor.cs
@@ -32,7 +32,7 @@ public partial class GridItem
     [CSSProperty]
     public bool? HideLarge { get; set; }
 
-	#endregion
+    #endregion
 
     [Parameter]
     public RenderFragment ChildContent { get; set; } = default!;

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Indicator/Indicator.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Indicator/Indicator.razor.cs
@@ -6,6 +6,6 @@ public partial class Indicator
     [CSSProperty]
     public Color Color { get; set; } = Color.Default;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Indicator/Indicator.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Indicator/Indicator.razor.cs
@@ -5,4 +5,7 @@ public partial class Indicator
     [Parameter]
     [CSSProperty]
     public Color Color { get; set; } = Color.Default;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/Modal.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/Modal.razor.cs
@@ -9,10 +9,10 @@ public partial class Modal
     [Parameter]
     public EventCallback OnClose { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public async Task Close()
+    public async Task Close()
     {
         Visible = false;
         await OnClose.InvokeAsync();

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/Modal.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/Modal.razor.cs
@@ -9,7 +9,10 @@ public partial class Modal
     [Parameter]
     public EventCallback OnClose { get; set; }
 
-    public async Task Close()
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public async Task Close()
     {
         Visible = false;
         await OnClose.InvokeAsync();

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalBody.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalBody.razor.cs
@@ -2,4 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalBody
 {
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalBody.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalBody.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalBody
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalFooter.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalFooter.razor.cs
@@ -2,5 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalFooter
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalFooter.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalFooter.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalFooter
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalHeader.razor.cs
@@ -11,7 +11,7 @@ public partial class ModalHeader
     [Parameter]
     public string? Title { get; set; }
 
-	[Parameter]
-	public RenderFragment? ChildContent { get; set; }
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
 }
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalHeader.razor.cs
@@ -10,5 +10,8 @@ public partial class ModalHeader
 
     [Parameter]
     public string? Title { get; set; }
+
+	[Parameter]
+	public RenderFragment? ChildContent { get; set; }
 }
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalTitle.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalTitle.razor.cs
@@ -2,5 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalTitle
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalTitle.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Modal/ModalTitle.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class ModalTitle
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Pagination/PaginationItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Pagination/PaginationItem.razor.cs
@@ -12,4 +12,7 @@ public partial class PaginationItem
 
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Pagination/PaginationItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Pagination/PaginationItem.razor.cs
@@ -13,6 +13,6 @@ public partial class PaginationItem
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stack/Stack.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stack/Stack.razor.cs
@@ -18,6 +18,6 @@ public partial class Stack
     [CSSProperty]
     public bool Vertical { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stack/Stack.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stack/Stack.razor.cs
@@ -17,4 +17,7 @@ public partial class Stack
     [Parameter]
     [CSSProperty]
     public bool Vertical { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/Stepper.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/Stepper.razor.cs
@@ -6,6 +6,6 @@ public partial class Stepper
     [CSSProperty]
     public bool Vertical { get; set; } = true;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/Stepper.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/Stepper.razor.cs
@@ -5,4 +5,7 @@ public partial class Stepper
     [Parameter]
     [CSSProperty]
     public bool Vertical { get; set; } = true;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/StepperItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/StepperItem.razor.cs
@@ -15,6 +15,6 @@ public partial class StepperItem
     [Parameter]
     public string? Title { get; set; }
 
-	[Parameter]
-	public RenderFragment? ChildContent { get; set; }
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/StepperItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Stepper/StepperItem.razor.cs
@@ -14,4 +14,7 @@ public partial class StepperItem
 
     [Parameter]
     public string? Title { get; set; }
+
+	[Parameter]
+	public RenderFragment? ChildContent { get; set; }
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabContent.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabContent.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabContent
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabContent.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabContent.razor.cs
@@ -2,5 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabContent
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabHeader.razor.cs
@@ -2,5 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabHeader
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabHeader.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabHeader.razor.cs
@@ -2,6 +2,6 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabHeader
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabItem.razor.cs
@@ -8,7 +8,10 @@ public partial class TabItem
     [Parameter]
     public string Name { get; set; } = default!;
 
-    [CascadingParameter]
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	[CascadingParameter]
     public Tabs? Parent { get; set; }
 
     private async Task OnClicked()

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabItem.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabItem.razor.cs
@@ -8,10 +8,10 @@ public partial class TabItem
     [Parameter]
     public string Name { get; set; } = default!;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	[CascadingParameter]
+    [CascadingParameter]
     public Tabs? Parent { get; set; }
 
     private async Task OnClicked()

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabList.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabList.razor.cs
@@ -2,6 +2,7 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabList
 {
-
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabList.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabList.razor.cs
@@ -2,7 +2,7 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class TabList
 {
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabPanel.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabPanel.razor.cs
@@ -8,7 +8,10 @@ public partial class TabPanel
     [Parameter]
     public string Name { get; set; } = default!;
 
-    [CascadingParameter]
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	[CascadingParameter]
     public Tabs? Parent { get; set; }
 }
 

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabPanel.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/TabPanel.razor.cs
@@ -8,11 +8,9 @@ public partial class TabPanel
     [Parameter]
     public string Name { get; set; } = default!;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	[CascadingParameter]
+    [CascadingParameter]
     public Tabs? Parent { get; set; }
 }
-
-

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
@@ -2,26 +2,26 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Tabs
 {
-	[Parameter]
-	public string Active { get; set; }
+    [Parameter]
+    public string Active { get; set; }
 
-	[Parameter]
-	public EventCallback<string> OnChange { get; set; }
+    [Parameter]
+    public EventCallback<string> OnChange { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public string Value { get; set; }
+    public string Value { get; set; }
 
-	protected override async Task OnInitializedAsync()
-	{
-		Value = Active;
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        Value = Active;
+    }
 
-	public async Task Activate(string name)
-	{
-		Value = name;
-		StateHasChanged();
-		await OnChange.InvokeAsync(Value);
-	}
+    public async Task Activate(string name)
+    {
+        Value = name;
+        StateHasChanged();
+        await OnChange.InvokeAsync(Value);
+    }
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
@@ -8,7 +8,10 @@ public partial class Tabs
     [Parameter]
     public EventCallback<string> OnChange { get; set; }
 
-    public string Value { get; set; }
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public string Value { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tabs/Tabs.razor.cs
@@ -2,26 +2,26 @@ namespace FluentCMS.Web.UI.Components;
 
 public partial class Tabs
 {
-    [Parameter]
-    public string Active { get; set; }
+	[Parameter]
+	public string Active { get; set; }
 
-    [Parameter]
-    public EventCallback<string> OnChange { get; set; }
+	[Parameter]
+	public EventCallback<string> OnChange { get; set; }
 
 	[Parameter]
 	public RenderFragment ChildContent { get; set; } = default!;
 
 	public string Value { get; set; }
 
-    protected override async Task OnInitializedAsync()
-    {
-        Value = Active;
-    }
+	protected override async Task OnInitializedAsync()
+	{
+		Value = Active;
+	}
 
-    public async Task Activate(string name)
-    {
-        Value = name;
-        StateHasChanged();
-        await OnChange.InvokeAsync(Value);
-    }
+	public async Task Activate(string name)
+	{
+		Value = name;
+		StateHasChanged();
+		await OnChange.InvokeAsync(Value);
+	}
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Toast/Toast.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Toast/Toast.razor.cs
@@ -12,7 +12,10 @@ public partial class Toast
     [CSSProperty]
     public ToastType Type { get; set; }
 
-    public void Close()
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public void Close()
     {
         Show = false;
     }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Toast/Toast.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Toast/Toast.razor.cs
@@ -12,10 +12,10 @@ public partial class Toast
     [CSSProperty]
     public ToastType Type { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public void Close()
+    public void Close()
     {
         Show = false;
     }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tooltip/Tooltip.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tooltip/Tooltip.razor.cs
@@ -12,7 +12,10 @@ public partial class Tooltip : IAsyncDisposable
     [Parameter]
     public TooltipPlacement? Placement { get; set; }
 
-    public async ValueTask DisposeAsync()
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	public async ValueTask DisposeAsync()
     {
         module.InvokeVoidAsync("dispose", DotNetObjectReference.Create(this), element);
     }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Tooltip/Tooltip.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Tooltip/Tooltip.razor.cs
@@ -12,10 +12,10 @@ public partial class Tooltip : IAsyncDisposable
     [Parameter]
     public TooltipPlacement? Placement { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	public async ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         module.InvokeVoidAsync("dispose", DotNetObjectReference.Create(this), element);
     }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Typography/Typography.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Typography/Typography.razor.cs
@@ -17,4 +17,7 @@ public partial class Typography
     [Parameter]
     [CSSProperty]
     public TextWeight Weight { get; set; } = TextWeight.Default;
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/FluentCMS.Web.UI.Components/Components/Typography/Typography.razor.cs
+++ b/src/Frontend/FluentCMS.Web.UI.Components/Components/Typography/Typography.razor.cs
@@ -18,6 +18,6 @@ public partial class Typography
     [CSSProperty]
     public TextWeight Weight { get; set; } = TextWeight.Default;
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 }

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Components/FieldSettingForm.razor.cs
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Components/FieldSettingForm.razor.cs
@@ -17,10 +17,10 @@ public partial class FieldSettingForm
     [Parameter, EditorRequired]
     public EventCallback OnSubmit { get; set; }
 
-	[Parameter]
-	public RenderFragment ChildContent { get; set; } = default!;
+    [Parameter]
+    public RenderFragment ChildContent { get; set; } = default!;
 
-	protected async Task OnFormSubmit()
+    protected async Task OnFormSubmit()
     {
         await OnSubmit.InvokeAsync();
     }

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Components/FieldSettingForm.razor.cs
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Components/FieldSettingForm.razor.cs
@@ -17,7 +17,10 @@ public partial class FieldSettingForm
     [Parameter, EditorRequired]
     public EventCallback OnSubmit { get; set; }
 
-    protected async Task OnFormSubmit()
+	[Parameter]
+	public RenderFragment ChildContent { get; set; } = default!;
+
+	protected async Task OnFormSubmit()
     {
         await OnSubmit.InvokeAsync();
     }


### PR DESCRIPTION
Removes the `public RenderFragment ChildContent { get; set; }` parameter from the `BaseComponent` and adds to the components that actually use them