### PR TITLE
Update token provider and fix typo in method name

### DIFF
--- a/src/Backend/FluentCMS.Services/ServiceExtensions.cs
+++ b/src/Backend/FluentCMS.Services/ServiceExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceExtensions
         });
 
         services.AddScoped<IUserTokenProvider, JwtUserTokenProvider>();
-        services.AddScoped<IApiTokenProvider, JwtApiTokenProvider>();
+        services.AddScoped<IApiTokenProvider, DefaultApiTokenProvider>();
         services.AddScoped(typeof(IMessageBus<>), typeof(MessageBus<>));
         services.AddScoped(typeof(IMessageSubscriber<>), typeof(MessageSubscriber<>));
         services.AddScoped(typeof(IMessagePublisher<>), typeof(MessagePublisher<>));

--- a/src/Backend/FluentCMS.Web.Api/Filters/ApiTokenAuthorizeFilter.cs
+++ b/src/Backend/FluentCMS.Web.Api/Filters/ApiTokenAuthorizeFilter.cs
@@ -71,7 +71,7 @@ public class ApiTokenAuthorizeFilter : IAsyncAuthorizationFilter
         var apiKey = parts[0];
         var secretKey = parts[1];
 
-        var checkSignature = apiTokenProvider.Valiadate(apiKey, secretKey);
+        var checkSignature = apiTokenProvider.Validate(apiKey, secretKey);
         if (!checkSignature)
             return false;
 


### PR DESCRIPTION
The `ServiceExtensions` class now registers `DefaultApiTokenProvider` instead of `JwtApiTokenProvider` for the `IApiTokenProvider` interface. The `ApiTokenAuthorizeFilter` class has a corrected method name from `Valiadate` to `Validate` for the `apiTokenProvider`'s method call.