### PR TITLE
Refactor user role fetching and remove message handlers

### DIFF
--- a/src/Backend/FluentCMS.Services/Permissions/PermissionManager.cs
+++ b/src/Backend/FluentCMS.Services/Permissions/PermissionManager.cs
@@ -45,7 +45,7 @@ public class PermissionManager : IPermissionManager
         if (_isSuperAdmin)
             return true;
 
-        _userRoles ??= (await _userRoleRepository.GetByUserId(_apiExecutionContext.UserId, cancellationToken)).Where(ur => ur.SiteId == siteId).ToList();
+        _userRoles ??= (await _userRoleRepository.GetUserRoles(_apiExecutionContext.UserId, siteId, cancellationToken)).Where(ur => ur.SiteId == siteId).ToList();
         _roles ??= (await _roleRepository.GetAllForSite(siteId, cancellationToken)).ToList();
 
         var adminRoleIds = _roles.Where(r => r.Type == RoleTypes.Administrators).Select(r => r.Id);

--- a/src/Backend/FluentCMS.Services/UserRoleService.cs
+++ b/src/Backend/FluentCMS.Services/UserRoleService.cs
@@ -9,7 +9,7 @@ public interface IUserRoleService : IAutoRegisterService
     Task<bool> Update(Guid userId, Guid siteId, IEnumerable<Guid> roleIds, CancellationToken cancellationToken = default);
 }
 
-public class UserRoleService(IUserRoleRepository userRoleRepository, IRoleRepository roleRepository, IApiExecutionContext apiExecutionContext) : IUserRoleService, IMessageHandler<Role>, IMessageHandler<User>
+public class UserRoleService(IUserRoleRepository userRoleRepository, IRoleRepository roleRepository, IApiExecutionContext apiExecutionContext) : IUserRoleService
 {
     public async Task<IEnumerable<Guid>> GetUserRoleIds(Guid userId, Guid siteId, CancellationToken cancellationToken = default)
     {
@@ -43,37 +43,5 @@ public class UserRoleService(IUserRoleRepository userRoleRepository, IRoleReposi
         await userRoleRepository.CreateMany(userRoles, cancellationToken);
 
         return true;
-    }
-
-    public async Task Handle(Message<Role> notification, CancellationToken cancellationToken)
-    {
-        switch (notification.Action)
-        {
-            case ActionNames.RoleDeleted:
-                await DeleteRoleForUsers(notification.Payload.Id, cancellationToken);
-                break;
-        }
-    }
-
-    private async Task DeleteRoleForUsers(Guid roleId, CancellationToken cancellationToken)
-    {
-        var userRoles = await userRoleRepository.GetByRoleId(roleId, cancellationToken);
-        await userRoleRepository.DeleteMany(userRoles.Select(x => x.Id));
-    }
-
-    public async Task Handle(Message<User> notification, CancellationToken cancellationToken)
-    {
-        switch (notification.Action)
-        {
-            case ActionNames.UserDeleted:
-                await DeleteByUserId(notification.Payload.Id, cancellationToken);
-                break;
-        }
-    }
-
-    private async Task DeleteByUserId(Guid userId, CancellationToken cancellationToken)
-    {
-        var userRoles = await userRoleRepository.GetByUserId(userId, cancellationToken);
-        await userRoleRepository.DeleteMany(userRoles.Select(x => x.Id), cancellationToken);
     }
 }

--- a/src/Backend/Repositories/FluentCMS.Repositories.Abstractions/IUserRoleRepository.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.Abstractions/IUserRoleRepository.cs
@@ -2,7 +2,6 @@
 
 public interface IUserRoleRepository : ISiteAssociatedRepository<UserRole>
 {
-    Task<IEnumerable<UserRole>> GetByUserId(Guid userId, CancellationToken cancellationToken = default);
     Task<IEnumerable<UserRole>> GetUserRoles(Guid userId, Guid siteId, CancellationToken cancellationToken = default);
     Task<IEnumerable<UserRole>> GetByRoleId(Guid roleId, CancellationToken cancellationToken = default);
 }

--- a/src/Backend/Repositories/FluentCMS.Repositories.LiteDb/UserRoleRepository.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.LiteDb/UserRoleRepository.cs
@@ -1,21 +1,11 @@
 ﻿namespace FluentCMS.Repositories.LiteDb;
 
-public class UserRoleRepository : SiteAssociatedRepository<UserRole>, IUserRoleRepository
+public class UserRoleRepository(ILiteDBContext liteDbContext, IApiExecutionContext apiExecutionContext) : SiteAssociatedRepository<UserRole>(liteDbContext, apiExecutionContext), IUserRoleRepository
 {
-    public UserRoleRepository(ILiteDBContext liteDbContext, IApiExecutionContext apiExecutionContext) : base(liteDbContext, apiExecutionContext)
-    {
-    }
-
     public async Task<IEnumerable<UserRole>> GetUserRoles(Guid userId, Guid siteId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return await Collection.Query().Where(x => x.SiteId == siteId && x.UserId == userId).ToListAsync();
-    }
-
-    public async Task<IEnumerable<UserRole>> GetByUserId(Guid userId, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return await Collection.Query().Where(x => x.UserId == userId).ToListAsync();
     }
 
     public async Task<IEnumerable<UserRole>> GetByRoleId(Guid roleId, CancellationToken cancellationToken = default)

--- a/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/UserRoleRepository.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/UserRoleRepository.cs
@@ -1,21 +1,11 @@
 ﻿namespace FluentCMS.Repositories.MongoDB;
 
-public class UserRoleRepository : SiteAssociatedRepository<UserRole>, IUserRoleRepository
+public class UserRoleRepository(IMongoDBContext mongoDbContext, IApiExecutionContext apiExecutionContext) : SiteAssociatedRepository<UserRole>(mongoDbContext, apiExecutionContext), IUserRoleRepository
 {
-    public UserRoleRepository(IMongoDBContext mongoDbContext, IApiExecutionContext apiExecutionContext) : base(mongoDbContext, apiExecutionContext)
-    {
-    }
-
     public async Task<IEnumerable<UserRole>> GetUserRoles(Guid userId, Guid siteId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return await Collection.Find(x => x.SiteId == siteId && x.UserId == userId).ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<UserRole>> GetByUserId(Guid userId, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return await Collection.Find(x => x.UserId == userId).ToListAsync(cancellationToken);
     }
 
     public async Task<IEnumerable<UserRole>> GetByRoleId(Guid roleId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Refactored user role fetching to include site-specific querying:
- PermissionManager.cs: Replaced `GetByUserId` with `GetUserRoles`.
- IUserRoleRepository.cs: Added `GetUserRoles` method, removed `GetByUserId`.
- UserRoleRepository.cs (LiteDb & MongoDB): Updated constructors, replaced `GetByUserId` with `GetUserRoles`.

Removed message handling for role and user deletions:
- UserRoleService.cs: Removed `IMessageHandler` implementations and related methods.