### PR TITLE
Refactor SiteService and update controllers

### DIFF
--- a/src/Backend/FluentCMS.Services/SiteService.cs
+++ b/src/Backend/FluentCMS.Services/SiteService.cs
@@ -20,21 +20,18 @@ public class SiteService(ISiteRepository siteRepository, IMessagePublisher messa
 
     public async Task<Site> GetById(Guid id, CancellationToken cancellationToken = default)
     {
-        var site = await siteRepository.GetById(id, cancellationToken) ??
+        if (!await permissionManager.HasAccess(id, SitePermissionAction.SiteAdmin, cancellationToken))
+            throw new AppException(ExceptionCodes.PermissionDenied);
+
+        return await siteRepository.GetById(id, cancellationToken) ??
             throw new AppException(ExceptionCodes.SiteNotFound);
-
-        //if (!await permissionManager.HasAccess(site, PermissionActionNames.SiteAdmin, cancellationToken))
-        //    throw new AppException(ExceptionCodes.PermissionDenied);
-
-        return site;
     }
 
     public async Task<Site> GetByUrl(string url, CancellationToken cancellationToken = default)
     {
-        var site = await siteRepository.GetByUrl(url, cancellationToken) ??
+        // no need to check permissions
+        return await siteRepository.GetByUrl(url, cancellationToken) ??
             throw new AppException(ExceptionCodes.SiteNotFound);
-
-        return site;
     }
 
     public async Task<Site> Create(SiteTemplate siteTemplate, CancellationToken cancellationToken = default)
@@ -74,8 +71,8 @@ public class SiteService(ISiteRepository siteRepository, IMessagePublisher messa
 
     public async Task<Site> Update(Site site, CancellationToken cancellationToken = default)
     {
-        //if (!await permissionManager.HasAccess(site, PermissionActionNames.SiteAdmin, cancellationToken))
-        //    throw new AppException(ExceptionCodes.PermissionDenied);
+        if (!await permissionManager.HasAccess(site.Id, SitePermissionAction.SiteAdmin, cancellationToken))
+            throw new AppException(ExceptionCodes.PermissionDenied);
 
         PrepareSite(site);
 
@@ -94,7 +91,7 @@ public class SiteService(ISiteRepository siteRepository, IMessagePublisher messa
 
     public async Task<Site> Delete(Guid id, CancellationToken cancellationToken = default)
     {
-        if (!await permissionManager.HasAccess(GlobalPermissionAction.SuperAdmin))
+        if (!await permissionManager.HasAccess(GlobalPermissionAction.SuperAdmin, cancellationToken))
             throw new AppException(ExceptionCodes.PermissionDenied);
 
         var originalSite = await siteRepository.GetById(id, cancellationToken) ??

--- a/src/Backend/FluentCMS.Web.Api/Controllers/PageController.cs
+++ b/src/Backend/FluentCMS.Web.Api/Controllers/PageController.cs
@@ -13,7 +13,6 @@ public class PageController(
     IUserRoleService userRoleService,
     ISetupService setupService,
     IApiExecutionContext apiExecutionContext,
-    IPermissionService permissionService,
     IMapper mapper) : BaseGlobalController
 {
 

--- a/src/Backend/FluentCMS.Web.Api/Controllers/SiteController.cs
+++ b/src/Backend/FluentCMS.Web.Api/Controllers/SiteController.cs
@@ -10,15 +10,6 @@ public class SiteController(ISiteService siteService, IMapper mapper) : BaseGlob
     public const string CREATE = "Create";
     public const string DELETE = $"Delete/{READ}";
 
-    [HttpGet("{siteUrl}")]
-    [Policy(AREA, READ)]
-    public async Task<IApiResult<SiteDetailResponse>> GetByUrl([FromRoute] string siteUrl, CancellationToken cancellationToken = default)
-    {
-        var site = await siteService.GetByUrl(siteUrl, cancellationToken);
-        var siteResponse = mapper.Map<SiteDetailResponse>(site);
-        return Ok(siteResponse);
-    }
-
     [HttpGet]
     [Policy(AREA, READ)]
     public async Task<IApiPagingResult<SiteDetailResponse>> GetAll(CancellationToken cancellationToken = default)


### PR DESCRIPTION
- Modify `GetById` in `SiteService.cs` to check permissions before fetching the site using `id` and `SitePermissionAction.SiteAdmin`.
- Simplify `GetByUrl` in `SiteService.cs` by removing the permission check.
- Update `Update` in `SiteService.cs` to include a permission check using `site.Id` and `SitePermissionAction.SiteAdmin`.
- Modify `Delete` in `SiteService.cs` to include a `cancellationToken` parameter in the permission check for `GlobalPermissionAction.SuperAdmin`.
- Remove `IPermissionService` dependency from `PageController` constructor.
- Remove `GetByUrl` method from `SiteController`, including its route and policy attributes.