### PR TITLE
Remove permission checks from RoleService methods

### DIFF
--- a/src/Backend/FluentCMS.Services/RoleService.cs
+++ b/src/Backend/FluentCMS.Services/RoleService.cs
@@ -13,9 +13,7 @@ public class RoleService(IRoleRepository roleRepository, IMessagePublisher messa
 {
     public async Task<IEnumerable<Role>> GetAllForSite(Guid siteId, CancellationToken cancellationToken = default)
     {
-        if (!await permissionManager.HasAccess(siteId, SitePermissionAction.SiteAdmin, cancellationToken))
-            throw new AppException(ExceptionCodes.PermissionDenied);
-
+        // no need to check for permission 
         return await roleRepository.GetAllForSite(siteId, cancellationToken);
     }
 
@@ -87,13 +85,8 @@ public class RoleService(IRoleRepository roleRepository, IMessagePublisher messa
 
     public async Task<Role> GetById(Guid roleId, CancellationToken cancellationToken = default)
     {
-        var existingRole = await roleRepository.GetById(roleId, cancellationToken) ??
+        // no need to check for permission
+        return await roleRepository.GetById(roleId, cancellationToken) ??
             throw new AppException(ExceptionCodes.RoleNotFound);
-
-        if (!await permissionManager.HasAccess(existingRole.SiteId, SitePermissionAction.SiteAdmin, cancellationToken))
-            throw new AppException(ExceptionCodes.PermissionDenied);
-
-        return existingRole;
-
     }
 }


### PR DESCRIPTION
Simplified the `RoleService` class by removing permission checks from the `GetAllForSite` and `GetById` methods. The `GetAllForSite` method no longer verifies `SiteAdmin` permissions for the specified site, and the `GetById` method no longer checks `SiteAdmin` permissions for the site associated with the role. Comments have been added to indicate that these permission checks are no longer necessary. The `GetById` method now directly returns the role or throws a `RoleNotFound` exception if the role does not exist.