### PR TITLE
Prevent deletion of default layouts and update dependencies

### DIFF
--- a/src/Backend/FluentCMS.Services/MessageHandlers/PageMessageHandler.cs
+++ b/src/Backend/FluentCMS.Services/MessageHandlers/PageMessageHandler.cs
@@ -1,7 +1,40 @@
 ﻿namespace FluentCMS.Services.MessageHandlers;
 
-public class PageMessageHandler(IPageService pageService, IPermissionService permissionService) : IMessageHandler<SiteTemplate>
+public class PageMessageHandler(IPageService pageService, IPermissionService permissionService) : IMessageHandler<SiteTemplate>, IMessageHandler<Layout>
 {
+    public async Task Handle(Message<Layout> notification, CancellationToken cancellationToken)
+    {
+        switch (notification.Action)
+        {
+            case ActionNames.LayoutDeleted:
+                var siteId = notification.Payload.SiteId;
+                var layoutId = notification.Payload.Id;
+                var allPages = await pageService.GetBySiteId(siteId, cancellationToken);
+                foreach (var page in allPages)
+                {
+                    if (page.LayoutId == layoutId)
+                    {
+                        page.LayoutId = null;
+                        await pageService.Update(page, cancellationToken);
+                    }
+                    if (page.DetailLayoutId == layoutId)
+                    {
+                        page.DetailLayoutId = null;
+                        await pageService.Update(page, cancellationToken);
+                    }
+                    if (page.EditLayoutId == layoutId)
+                    {
+                        page.EditLayoutId = null;
+                        await pageService.Update(page, cancellationToken);
+                    }
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
     public async Task Handle(Message<SiteTemplate> notification, CancellationToken cancellationToken)
     {
         switch (notification.Action)
@@ -53,4 +86,5 @@ public class PageMessageHandler(IPageService pageService, IPermissionService per
 
         await CreatePageTemplates(page.Id, pageTemplate.Children, siteTemplate, cancellationToken);
     }
+
 }

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/LayoutManagement/LayoutListPlugin.razor
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/LayoutManagement/LayoutListPlugin.razor
@@ -13,8 +13,8 @@
             <DataTableItem Label="Modified By">@(context.ModifiedBy ?? string.Empty)</DataTableItem>
             <DataTableItem Label="Modified At">@context.ModifiedAt</DataTableItem>
             <ActionButtons>
+                <ActionButtonDelete Visible="@(context.Id != ViewState.Layout.Id && context.Id != ViewState.EditLayout.Id && context.Id != ViewState.DetailLayout.Id)" @onclick="() => OnConfirm(context)" />
                 <ActionButtonEdit Href="@GetUrl("Update Layout", new { id = @context.Id })" />
-                <ActionButtonDelete @onclick="() => OnConfirm(context)" />
             </ActionButtons>
         </DataTable>
     </ChildContent>

--- a/src/Shared/Exceptions/ExceptionCodes.cs
+++ b/src/Shared/Exceptions/ExceptionCodes.cs
@@ -110,6 +110,7 @@ public static class ExceptionCodes
     public const string LayoutUnableToUpdate = "Layout.UnableToUpdate";
     public const string LayoutUnableToDelete = "Layout.UnableToDelete";
     public const string LayoutNotFound = "Layout.NotFound";
+    public const string LayoutUnableToDeleteDefaultLayout = "Layout.UnableToDeleteDefaultLayout";
 
     #endregion
 


### PR DESCRIPTION
Updated ILayoutService to include ISiteRepository dependency. Modified LayoutService constructor to accept ISiteRepository. Added logic in LayoutService.Delete to prevent deleting default layouts. Implemented IMessageHandler<Layout> in PageMessageHandler. Added Handle method in PageMessageHandler for LayoutDeleted actions. Updated LayoutListPlugin.razor to hide delete button for default layouts. Added LayoutUnableToDeleteDefaultLayout exception code.