### PR TITLE
Set Description and Name in SiteController.Create

### DIFF
--- a/src/Backend/FluentCMS.Web.Api/Controllers/SiteController.cs
+++ b/src/Backend/FluentCMS.Web.Api/Controllers/SiteController.cs
@@ -35,6 +35,8 @@ public class SiteController(ISiteService siteService, IMapper mapper, IPluginDef
         var siteTemplate = mapper.Map<SiteTemplate>(request);
         var pluginDefinitions = await pluginDefinitionService.GetAll(cancellationToken);
         await siteTemplate.Load(pluginDefinitions, cancellationToken);
+        siteTemplate.Description = request.Description ?? string.Empty;
+        siteTemplate.Name = request.Name;
         var newSite = await siteService.Create(siteTemplate, cancellationToken);
         var response = mapper.Map<SiteDetailResponse>(newSite);
         return Ok(response);


### PR DESCRIPTION
Added code to set the `Description` and `Name` properties of the `siteTemplate` object in the `Create` method of the `SiteController` class. The `Description` defaults to an empty string if not provided.