### PR TITLE
Update various package versions across multiple projects

### DIFF
--- a/src/Backend/FluentCMS.Entities/FluentCMS.Entities.csproj
+++ b/src/Backend/FluentCMS.Entities/FluentCMS.Entities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Backend/FluentCMS.Services/FluentCMS.Services.csproj
+++ b/src/Backend/FluentCMS.Services/FluentCMS.Services.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Backend/FluentCMS.Web.Api/FluentCMS.Web.Api.csproj
+++ b/src/Backend/FluentCMS.Web.Api/FluentCMS.Web.Api.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="13.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Backend/Repositories/FluentCMS.Repositories.Caching/FluentCMS.Repositories.Caching.csproj
+++ b/src/Backend/Repositories/FluentCMS.Repositories.Caching/FluentCMS.Repositories.Caching.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Scrutor" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/FluentCMS.Repositories.MongoDB.csproj
+++ b/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/FluentCMS.Repositories.MongoDB.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Humanizer" Version="2.14.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/MongoDBServiceExtensions.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.MongoDB/MongoDBServiceExtensions.cs
@@ -12,7 +12,6 @@ public static class MongoDbServiceExtensions
     {
         // register default GUID serializer for MongoDB
         BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
-        BsonDefaults.GuidRepresentation = GuidRepresentation.Standard;
 
         // Register MongoDB context and options
         services.AddSingleton(provider => CreateMongoDBOptions(provider, connectionString));

--- a/src/Frontend/FluentCMS.Web.ApiClients/FluentCMS.Web.ApiClients.csproj
+++ b/src/Frontend/FluentCMS.Web.ApiClients/FluentCMS.Web.ApiClients.csproj
@@ -8,8 +8,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="13.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Frontend/FluentCMS.Web.UI.Components/FluentCMS.Web.UI.Components.csproj
+++ b/src/Frontend/FluentCMS.Web.UI.Components/FluentCMS.Web.UI.Components.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Frontend/FluentCMS.Web.UI/FluentCMS.Web.UI.csproj
+++ b/src/Frontend/FluentCMS.Web.UI/FluentCMS.Web.UI.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/FluentCMS.Web.Plugins.Admin.csproj
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/FluentCMS.Web.Plugins.Admin.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="8.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Providers/ApiTokenProviders/FluentCMS.Providers.ApiTokenProviders/FluentCMS.Providers.ApiTokenProviders.csproj
+++ b/src/Providers/ApiTokenProviders/FluentCMS.Providers.ApiTokenProviders/FluentCMS.Providers.ApiTokenProviders.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Providers/CacheProviders/FluentCMS.Providers.CacheProviders/FluentCMS.Providers.CacheProviders.csproj
+++ b/src/Providers/CacheProviders/FluentCMS.Providers.CacheProviders/FluentCMS.Providers.CacheProviders.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Providers/MessageBusProviders/FluentCMS.Providers.MessageBusProviders/FluentCMS.Providers.MessageBusProviders.csproj
+++ b/src/Providers/MessageBusProviders/FluentCMS.Providers.MessageBusProviders/FluentCMS.Providers.MessageBusProviders.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Providers/TemplateRenderingProviders/FluentCMS.Providers.TemplateRenderingProviders/FluentCMS.Providers.TemplateRenderingProviders.csproj
+++ b/src/Providers/TemplateRenderingProviders/FluentCMS.Providers.TemplateRenderingProviders/FluentCMS.Providers.TemplateRenderingProviders.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Scriban" Version="5.10.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated the following project files to use newer package versions:
- `FluentCMS.Entities.csproj`: `Microsoft.Extensions.Identity.Stores` to `8.0.10`
- `FluentCMS.Services.csproj`: `Microsoft.AspNetCore.Authentication.JwtBearer` to `8.0.10`
- `FluentCMS.Web.Api.csproj`: `Swashbuckle.AspNetCore` to `6.9.0`
- `FluentCMS.Repositories.Caching.csproj`: `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.2`, `Scrutor` to `5.0.1`
- `FluentCMS.Repositories.MongoDB.csproj`: `MongoDB.Driver` to `3.0.0`
- `FluentCMS.Web.ApiClients.csproj`: `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.2`, `Microsoft.Extensions.Http` to `8.0.1`
- `FluentCMS.Web.UI.Components.csproj`: `Microsoft.AspNetCore.Components.Web` to `8.0.10`
- `FluentCMS.Web.UI.csproj`: `Microsoft.AspNetCore.Components.Authorization` and `Microsoft.AspNetCore.Components.Web` to `8.0.10`
- `FluentCMS.Web.Plugins.Admin.csproj`: `Microsoft.AspNetCore.Components.Forms` and `Microsoft.AspNetCore.Components.Web` to `8.0.10`
- `FluentCMS.Providers.ApiTokenProviders.csproj`: `System.IdentityModel.Tokens.Jwt` to `8.1.2`
- `FluentCMS.Providers.CacheProviders.csproj`: `Microsoft.Extensions.Caching.Memory` to `8.0.1`
- `FluentCMS.Providers.MessageBusProviders.csproj`: `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.2`
- `FluentCMS.Providers.TemplateRenderingProviders.csproj`: `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.2`

Additionally, removed `BsonDefaults.GuidRepresentation` setting from `MongoDBServiceExtensions.cs`.