### PR TITLE
Refactor ContentRepository and IContentRepository

### DIFF
--- a/src/Backend/Repositories/FluentCMS.Repositories.Abstractions/IContentRepository.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.Abstractions/IContentRepository.cs
@@ -1,6 +1,6 @@
 ﻿namespace FluentCMS.Repositories.Abstractions;
 
-public interface IContentRepository : IAuditableEntityRepository<Content>
+public interface IContentRepository : ISiteAssociatedRepository<Content>
 {
     Task<IEnumerable<Content>> GetAll(Guid contentTypeId, CancellationToken cancellationToken = default);
 }

--- a/src/Backend/Repositories/FluentCMS.Repositories.LiteDb/ContentRepository.cs
+++ b/src/Backend/Repositories/FluentCMS.Repositories.LiteDb/ContentRepository.cs
@@ -1,6 +1,6 @@
 ﻿namespace FluentCMS.Repositories.LiteDb;
 
-public class ContentRepository(ILiteDBContext liteDbContext, IApiExecutionContext apiExecutionContext) : AuditableEntityRepository<Content>(liteDbContext, apiExecutionContext),
+public class ContentRepository(ILiteDBContext liteDbContext, IApiExecutionContext apiExecutionContext) : SiteAssociatedRepository<Content>(liteDbContext, apiExecutionContext),
     IContentRepository
 {
     public async Task<IEnumerable<Content>> GetAll(Guid contentTypeId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Updated IContentRepository to inherit from ISiteAssociatedRepository<Content> and added GetAll method. Modified ContentRepository to inherit from SiteAssociatedRepository<Content> and implemented the new GetAll method.