### PR TITLE
Add bulk delete to BlockService and update message handlers

### DIFF
--- a/src/Backend/FluentCMS.Services/BlockService.cs
+++ b/src/Backend/FluentCMS.Services/BlockService.cs
@@ -7,6 +7,7 @@ public interface IBlockService : IAutoRegisterService
     Task<Block> Create(Block Block, CancellationToken cancellationToken = default);
     Task<Block> Update(Block Block, CancellationToken cancellationToken = default);
     Task<Block> Delete(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Block>> Delete(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
 }
 
 public class BlockService(IBlockRepository blockRepository) : IBlockService
@@ -50,5 +51,10 @@ public class BlockService(IBlockRepository blockRepository) : IBlockService
 
         return await blockRepository.Delete(id, cancellationToken) ??
             throw new AppException(ExceptionCodes.BlockUnableToDelete);
+    }
+
+    public async Task<IEnumerable<Block>> Delete(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
+    {
+        return await blockRepository.DeleteMany(ids, cancellationToken);
     }
 }

--- a/src/Backend/FluentCMS.Services/MessageHandlers/BlockMessageHandler.cs
+++ b/src/Backend/FluentCMS.Services/MessageHandlers/BlockMessageHandler.cs
@@ -1,6 +1,6 @@
 namespace FluentCMS.Services.MessageHandlers;
 
-public class BlockMessageHandler(IBlockService blockService) : IMessageHandler<SiteTemplate>
+public class BlockMessageHandler(IBlockService blockService) : IMessageHandler<SiteTemplate>, IMessageHandler<Site>
 {
     public async Task Handle(Message<SiteTemplate> notification, CancellationToken cancellationToken)
     {
@@ -12,6 +12,21 @@ public class BlockMessageHandler(IBlockService blockService) : IMessageHandler<S
                     block.SiteId = notification.Payload.Id;
                     await blockService.Create(block, cancellationToken);
                 }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    public async Task Handle(Message<Site> notification, CancellationToken cancellationToken)
+    {
+        switch (notification.Action)
+        {
+            case ActionNames.SiteDeleted:
+                var siteId = notification.Payload.Id;
+                var blockIds = (await blockService.GetAllForSite(siteId, cancellationToken)).Select(b => b.Id);
+                await blockService.Delete(blockIds, cancellationToken);
                 break;
 
             default:

--- a/src/Backend/FluentCMS.Services/MessageHandlers/PermissionMessageHandler.cs
+++ b/src/Backend/FluentCMS.Services/MessageHandlers/PermissionMessageHandler.cs
@@ -16,7 +16,7 @@ public class PermissionMessageHandler(IPermissionService permissionService) : IM
 
                 break;
 
-            case ActionNames.SiteDeleted:
+            default:
                 break;
         }
     }

--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/SiteManagement/SiteListPlugin.razor
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/SiteManagement/SiteListPlugin.razor
@@ -28,7 +28,7 @@
             </DataTableItem>
             <ActionButtons>
                 <ActionButtonEdit Href="@GetUrl("Update Site", new { id = @context.Id })" />
-                <ActionButtonDelete @onclick="() => OnConfirm(context)" />
+                <ActionButtonDelete @onclick="() => OnConfirm(context)" Visible="ViewState.Site.Id != context.Id" />
             </ActionButtons>
         </DataTable>
     </ChildContent>


### PR DESCRIPTION
Added a new method `Delete(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)` to the `IBlockService` interface and its implementation in the `BlockService` class, enabling the deletion of multiple blocks by their IDs.

Updated `BlockMessageHandler` to implement `IMessageHandler<Site>` in addition to `IMessageHandler<SiteTemplate>`, including a new `Handle` method to delete all blocks associated with a site when a site is deleted.

Modified `PermissionMessageHandler` to handle the `SiteDeleted` action by default, ensuring no specific action is taken when a site is deleted.

Updated `SiteListPlugin.razor` to conditionally display the delete button based on the current view state, hiding the delete button if the site ID matches the current view state.