### PR TITLE
Add handling for DATE_TIME in ModelHelpers

### DIFF
--- a/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Models/ModelHelpers.cs
+++ b/src/Frontend/Plugins/FluentCMS.Web.Plugins.Admin/ContentTypeManagement/Models/ModelHelpers.cs
@@ -26,6 +26,9 @@ public static class ModelHelpers
                 return new FieldValue<bool> { Name = fieldModel.Name, Value = valuesDict.TryGetValue(fieldModel.Name, out object? boolValue) && ((bool?)boolValue ?? false) };
 
             case FieldTypes.DATE_TIME:
+                if (valuesDict[fieldModel.Name] is DateTime _dateTime)
+                    return new FieldValue<DateTime?> { Name = fieldModel.Name, Value = _dateTime };
+
                 // try parse the value as a DateTime
                 if (valuesDict[fieldModel.Name] is string dateTimeStr && DateTime.TryParse(dateTimeStr, out DateTime dateTime))
                     return new FieldValue<DateTime?> { Name = fieldModel.Name, Value = dateTime };


### PR DESCRIPTION
Introduce a new case for handling FieldTypes.DATE_TIME in the ModelHelpers class. The code checks if the value in valuesDict is a DateTime object or a string. If it's a DateTime object, it returns a FieldValue<DateTime?> with the DateTime value. If it's a string, it attempts to parse it as a DateTime and returns a FieldValue<DateTime?> with the parsed value. If neither condition is met, it returns a FieldValue<DateTime?> with a null value.