### PR TITLE
Add validation methods to IAccountService and SetupController

### DIFF
--- a/src/Backend/FluentCMS.Web.Api/Controllers/SetupController.cs
+++ b/src/Backend/FluentCMS.Web.Api/Controllers/SetupController.cs
@@ -2,7 +2,7 @@
 
 namespace FluentCMS.Web.Api.Controllers;
 
-public class SetupController(ISetupService setupService, IMapper mapper) : BaseGlobalController
+public class SetupController(ISetupService setupService, IMapper mapper, IAccountService accountService) : BaseGlobalController
 {
     public const string AREA = "Setup Management";
     public const string READ = "Read";
@@ -19,6 +19,8 @@ public class SetupController(ISetupService setupService, IMapper mapper) : BaseG
     [Policy(AREA, CREATE)]
     public async Task<IApiResult<bool>> Start(SetupRequest request)
     {
+        await accountService.ValidateUserName(request.Username);
+        await accountService.ValidatePassword(request.Password);
         var setupTemplate = mapper.Map<SetupTemplate>(request);
         return Ok(await setupService.Start(setupTemplate));
     }

--- a/src/Shared/Exceptions/ExceptionCodes.cs
+++ b/src/Shared/Exceptions/ExceptionCodes.cs
@@ -24,6 +24,8 @@ public static class ExceptionCodes
     public const string UserChangePasswordFailed = "User.ChangePasswordFailed";
     public const string UserTokenGenerationFailed = "User.TokenGenerationFailed";
     public const string UserSuperAdminCanNotBeDeleted = "User.SuperAdminCanNotBeDeleted";
+    public const string UserInvalidPassword = "User.InvalidPassword";
+    public const string UserInvalidUsername = "User.InvalidUsername";
 
     #endregion
 


### PR DESCRIPTION
- Added `ValidatePassword` and `ValidateUserName` methods to `IAccountService`.
- Implemented these methods in `AccountService` for password and username validation.
- Modified `SetupController` to include `IAccountService` and validate user input.
- Introduced new exception codes `UserInvalidPassword` and `UserInvalidUsername`.