### PR TITLE
Change InvariantGlobalization to false in FluentCMS.csproj

### DIFF
--- a/src/FluentCMS/FluentCMS.csproj
+++ b/src/FluentCMS/FluentCMS.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <InvariantGlobalization>true</InvariantGlobalization>
+        <InvariantGlobalization>false</InvariantGlobalization>
         <Version>0.0.0.0</Version>
     </PropertyGroup>
 


### PR DESCRIPTION
Modified FluentCMS.csproj to set InvariantGlobalization to false. This change makes the application use the system's culture settings instead of invariant (culture-independent) settings, affecting how globalization and culture-specific operations are handled.