### PR TITLE
Remove MySQL support from FluentCMS

### DIFF
--- a/src/FluentCMS/FluentCMS.csproj
+++ b/src/FluentCMS/FluentCMS.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Backend\FluentCMS.Web.Api\FluentCMS.Web.Api.csproj" />
     <ProjectReference Include="..\Backend\Repositories\FluentCMS.Repositories.Caching\FluentCMS.Repositories.Caching.csproj" />
-    <ProjectReference Include="..\Backend\Repositories\FluentCMS.Repositories.EFCore.MySql\FluentCMS.Repositories.EFCore.MySql.csproj" />
     <ProjectReference Include="..\Backend\Repositories\FluentCMS.Repositories.EFCore.PostgreSQL\FluentCMS.Repositories.EFCore.PostgreSQL.csproj" />
     <ProjectReference Include="..\Backend\Repositories\FluentCMS.Repositories.EFCore.Sqlite\FluentCMS.Repositories.EFCore.Sqlite.csproj" />
     <ProjectReference Include="..\Backend\Repositories\FluentCMS.Repositories.EFCore.SqlServer\FluentCMS.Repositories.EFCore.SqlServer.csproj" />

--- a/src/FluentCMS/RepositoryServiceExtensions.cs
+++ b/src/FluentCMS/RepositoryServiceExtensions.cs
@@ -23,9 +23,9 @@
             case "sqlserver":
                 services.AddSqlServerRepositories(connectionStringName);
                 break;
-            case "mysql":
-                services.AddMySqlRepositories(connectionStringName);
-                break;
+            //case "mysql":
+            //    services.AddMySqlRepositories(connectionStringName);
+            //    break;
             case "postgresql":
                 services.AddPostgresRepositories(connectionStringName);
                 break;


### PR DESCRIPTION
Removed the project reference to `FluentCMS.Repositories.EFCore.MySql` from the `FluentCMS.csproj` file. Commented out the MySQL repository service registration in `RepositoryServiceExtensions.cs`. These changes indicate that MySQL support is being removed or temporarily disabled.