### PR TITLE
Refactor query methods to use lists instead of enumerables

### DIFF
--- a/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
+++ b/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
@@ -42,6 +42,6 @@ internal class TodoService(ITodoRepository todoRepository) : ITodoService
 
     public async Task<IEnumerable<Todo>> GetAll(CancellationToken cancellationToken = default)
     {
-        return await todoRepository.Query().ToEnumerable(cancellationToken);
+        return await todoRepository.Query().ToList(cancellationToken);
     }
 }

--- a/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
+++ b/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
@@ -6,7 +6,7 @@ namespace FluentCMS.Plugins.TodoManager.Services;
 public interface ITodoService
 {
     Task<Todo> Add(Todo entity, CancellationToken cancellationToken = default);
-    Task<IList<Todo>> GetAll(CancellationToken cancellationToken = default);
+    Task<List<Todo>> GetAll(CancellationToken cancellationToken = default);
     Task<Todo?> GetById(Guid entityId, CancellationToken cancellationToken = default);
     Task Remove(Guid entityId, CancellationToken cancellationToken = default);
     Task<Todo> Update(Todo entity, CancellationToken cancellationToken = default);

--- a/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
+++ b/src/Infrastructure/Plugins/FluentCMS.Plugins.TodoManager/Services/TodoService.cs
@@ -6,7 +6,7 @@ namespace FluentCMS.Plugins.TodoManager.Services;
 public interface ITodoService
 {
     Task<Todo> Add(Todo entity, CancellationToken cancellationToken = default);
-    Task<IEnumerable<Todo>> GetAll(CancellationToken cancellationToken = default);
+    Task<IList<Todo>> GetAll(CancellationToken cancellationToken = default);
     Task<Todo?> GetById(Guid entityId, CancellationToken cancellationToken = default);
     Task Remove(Guid entityId, CancellationToken cancellationToken = default);
     Task<Todo> Update(Todo entity, CancellationToken cancellationToken = default);
@@ -40,7 +40,7 @@ internal class TodoService(ITodoRepository todoRepository) : ITodoService
         //return todoRepository.GetById(entityId, cancellationToken);
     }
 
-    public async Task<IEnumerable<Todo>> GetAll(CancellationToken cancellationToken = default)
+    public async Task<IList<Todo>> GetAll(CancellationToken cancellationToken = default)
     {
         return await todoRepository.Query().ToList(cancellationToken);
     }

--- a/src/Infrastructure/Providers/Core/FluentCMS.Providers.Repositories.EntityFramework/ProviderDataSeeder.cs
+++ b/src/Infrastructure/Providers/Core/FluentCMS.Providers.Repositories.EntityFramework/ProviderDataSeeder.cs
@@ -11,7 +11,7 @@ public class ProviderDataSeeder(IProviderManager providerManager, ConfigurationR
     public override async Task SeedData(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var providers = await readOnlyProviderRepository.Query().ToEnumerable(cancellationToken);
+        var providers = await readOnlyProviderRepository.Query().ToList(cancellationToken);
         var providerCatalogs = new List<ProviderCatalog>();
         foreach (var provider in providers)
         {

--- a/src/Infrastructure/Providers/Core/FluentCMS.Providers/ProviderManager.cs
+++ b/src/Infrastructure/Providers/Core/FluentCMS.Providers/ProviderManager.cs
@@ -28,7 +28,7 @@ internal sealed class ProviderManager(ProviderCatalogCache providerCatalogCache,
         if (providerCatalogCache.IsInitialized)
             return;
 
-        var providers = await repository.Query().ToEnumerable(cancellationToken);
+        var providers = await repository.Query().ToList(cancellationToken);
         IEnumerable<ProviderCatalog> providerCatalogs = [];
 
         foreach (var provider in providers)

--- a/src/Infrastructure/Repositories/FluentCMS.Repositories/Abstractions/IQuerySpecification.cs
+++ b/src/Infrastructure/Repositories/FluentCMS.Repositories/Abstractions/IQuerySpecification.cs
@@ -23,7 +23,6 @@ public interface IQuerySpecification<TEntity>
     Task<TEntity> Single(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
     Task<List<TEntity>> ToList(CancellationToken cancellationToken = default);
     Task<TEntity[]> ToArray(CancellationToken cancellationToken = default);
-    Task<IEnumerable<TEntity>> ToEnumerable(CancellationToken cancellationToken = default);
 
     // Aggregate operations
     Task<int> Count(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);

--- a/src/Infrastructure/Repositories/FluentCMS.Repositories/QuerySpecification.cs
+++ b/src/Infrastructure/Repositories/FluentCMS.Repositories/QuerySpecification.cs
@@ -85,9 +85,6 @@ public class QuerySpecification<TEntity> : IQuerySpecification<TEntity>
     public async Task<TEntity[]> ToArray(CancellationToken cancellationToken = default) =>
         await _queryable.ToArrayAsync(cancellationToken);
 
-    public async Task<IEnumerable<TEntity>> ToEnumerable(CancellationToken cancellationToken = default) =>
-        await _queryable.ToListAsync(cancellationToken);
-
     // Aggregate operations
     public async Task<int> Count(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default) =>
         await _queryable.CountAsync(predicate, cancellationToken);


### PR DESCRIPTION
Updated multiple classes to replace `ToEnumerable` with `ToList` for improved performance and consistency.
- `TodoService.GetAll` now returns a list.
- `ProviderDataSeeder.SeedData` updated to return a list.
- `ProviderManager.Initialize` modified to return a list.
- Removed `ToEnumerable` from `IQuerySpecification<TEntity>` interface.
- `QuerySpecification<TEntity>` now uses `ToListAsync` instead of `ToEnumerable`.